### PR TITLE
:sparkles: 낭만우편함 고민 편지 목록 조회 API 구현

### DIFF
--- a/src/main/java/aromanticcat/umcproject/converter/NangmanPostBoxConverter.java
+++ b/src/main/java/aromanticcat/umcproject/converter/NangmanPostBoxConverter.java
@@ -10,17 +10,29 @@ public class NangmanPostBoxConverter {
 
         return NangmanPostBoxResponseDTO.SendLetterResultDTO.builder()
                 .nangmanLetterId(nangmanLetter.getId())
-                .senderNickname(nangmanLetter.getSender_nickname())
+                .senderNickname(nangmanLetter.getSenderNickname())
                 .createdAt(nangmanLetter.getCreatedAt())
                 .build();
     }
 
     public static NangmanLetter toNangmanLetter(NangmanPostBoxRequestDTO.SendLetterDTO request){
         return NangmanLetter.builder()
-                .is_public(request.getIsPublic())
+                .isPublic(request.getIsPublic())
                 .content(request.getContent())
-                .sender_nickname(request.getSenderRandomNickname())
+                .senderNickname(request.getSenderRandomNickname())
 //                .member(request.getMember())
+                .build();
+    }
+
+    public static NangmanPostBoxResponseDTO.LetterSummaryResultDTO toLetterSummaryResultDTO(NangmanLetter nangmanLetter){
+        // 편지 내용을 40자 까지만 보이도록
+        String content = nangmanLetter.getContent();
+        String preview = content.length() <= 40 ? content: content.substring(0, 40) + "...";
+
+        return NangmanPostBoxResponseDTO.LetterSummaryResultDTO.builder()
+                .nangmanLetterId(nangmanLetter.getId())
+                .preview(preview)
+                .createdAt(nangmanLetter.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/aromanticcat/umcproject/entity/NangmanLetter.java
+++ b/src/main/java/aromanticcat/umcproject/entity/NangmanLetter.java
@@ -18,35 +18,35 @@ public class NangmanLetter extends BaseEntity {
     private Long id;
 
     @NotNull
-    private String sender_nickname;
+    private String senderNickname;
 
     @NotNull
-    private Boolean is_public;
+    private Boolean isPublic;
 
     @NotNull
     private String content;
 
     @NotNull
     @Builder.Default
-    private Boolean has_response = false;
+    private Boolean hasResponse = false;
 
-    private Integer thumbs_up_cnt;
+    private Integer thumbsUpCnt;
 
-    private Integer heart_cnt;
+    private Integer heartCnt;
 
-    private Integer crying_cnt;
+    private Integer cryingCnt;
 
-    private Integer clover_cnt;
+    private Integer cloverCnt;
 
-    private Integer clap_cnt;
+    private Integer clapCnt;
 
-    private Integer star_cnt;
+    private Integer starCnt;
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    public void change(Boolean has_response){
-        this.has_response = has_response;
+    public void change(Boolean hasResponse){
+        this.hasResponse = hasResponse;
     }
 }

--- a/src/main/java/aromanticcat/umcproject/repository/NangmanLetterRepository.java
+++ b/src/main/java/aromanticcat/umcproject/repository/NangmanLetterRepository.java
@@ -3,5 +3,10 @@ package aromanticcat.umcproject.repository;
 import aromanticcat.umcproject.entity.NangmanLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NangmanLetterRepository extends JpaRepository<NangmanLetter, Long> {
+
+    List<NangmanLetter> findByHasResponseFalse();
+
 }

--- a/src/main/java/aromanticcat/umcproject/service/NangmanPostBoxService.java
+++ b/src/main/java/aromanticcat/umcproject/service/NangmanPostBoxService.java
@@ -3,10 +3,14 @@ package aromanticcat.umcproject.service;
 import aromanticcat.umcproject.entity.NangmanLetter;
 import aromanticcat.umcproject.web.dto.NangmanPostBoxRequestDTO;
 
-public interface NangmanLetterService {
+import java.util.List;
+
+public interface NangmanPostBoxService {
 
     NangmanLetter writeAndSendLetter(NangmanPostBoxRequestDTO.SendLetterDTO requestDTO, String randomNickname);
-//
+
+    List<NangmanLetter> getLetterList();
+
 //    NangmanLetterDTO readOne(Long id);
 //
 //    void receivedReply(NangmanLetterDTO nangmanLetterDTO);

--- a/src/main/java/aromanticcat/umcproject/service/NangmanPostBoxServiceImpl.java
+++ b/src/main/java/aromanticcat/umcproject/service/NangmanPostBoxServiceImpl.java
@@ -9,11 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class NangmanLetterServiceImpl implements NangmanLetterService{
+public class NangmanPostBoxServiceImpl implements NangmanPostBoxService {
 
     private final NangmanLetterRepository nangmanLetterRepository;
     private final MemberRepository memberRepository;
@@ -25,6 +26,12 @@ public class NangmanLetterServiceImpl implements NangmanLetterService{
         NangmanLetter newNangmanLetter = NangmanPostBoxConverter.toNangmanLetter(request);
 
         return nangmanLetterRepository.save(newNangmanLetter);
+    }
+
+    @Override
+    @Transactional
+    public List<NangmanLetter> getLetterList(){
+        return nangmanLetterRepository.findByHasResponseFalse();
     }
 //
 //    @Override

--- a/src/main/java/aromanticcat/umcproject/web/controller/NangmanPostBoxController.java
+++ b/src/main/java/aromanticcat/umcproject/web/controller/NangmanPostBoxController.java
@@ -3,7 +3,7 @@ package aromanticcat.umcproject.web.controller;
 import aromanticcat.umcproject.apiPayload.ApiResponse;
 import aromanticcat.umcproject.converter.NangmanPostBoxConverter;
 import aromanticcat.umcproject.entity.NangmanLetter;
-import aromanticcat.umcproject.service.NangmanLetterService;
+import aromanticcat.umcproject.service.NangmanPostBoxService;
 import aromanticcat.umcproject.service.RandomNicknameService;
 import aromanticcat.umcproject.web.dto.NangmanPostBoxRequestDTO;
 import aromanticcat.umcproject.web.dto.NangmanPostBoxResponseDTO;
@@ -12,16 +12,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestController
 @RequestMapping("/nangman-post")
 @RequiredArgsConstructor
 public class NangmanPostBoxController {
 
-    private final NangmanLetterService nangmanLetterService;
+    private final NangmanPostBoxService nangmanPostBoxService;
     private final RandomNicknameService randomNicknameService;
 
     @GetMapping("/send/random-nickname")
-    @ApiOperation(value = "낭만 우편함 편지에 사용될 랜덤 닉네임 생성")
+    @ApiOperation(value = "낭만우편함 고민 편지에 사용될 랜덤 닉네임 생성")
     public ApiResponse<String> getRandomNickname(){
         try {
             //랜덤 닉네임 생성
@@ -36,12 +39,12 @@ public class NangmanPostBoxController {
 
 
     @PostMapping("/send")
-    @ApiOperation(value = "낭만 우편함 편지 작성")
+    @ApiOperation(value = "낭만우편함 고민 편지 발송")
     public ApiResponse<NangmanPostBoxResponseDTO.SendLetterResultDTO> sendLetter(@RequestBody NangmanPostBoxRequestDTO.SendLetterDTO request){
         try{
             //편지 작성 및 발송
             String senderNickname = request.getSenderRandomNickname();
-            NangmanLetter nangmanLetter = nangmanLetterService.writeAndSendLetter(request, senderNickname);
+            NangmanLetter nangmanLetter = nangmanPostBoxService.writeAndSendLetter(request, senderNickname);
 
             //성공 응답 생성
             return ApiResponse.onSuccess(NangmanPostBoxConverter.toSendLetterResultDTO(nangmanLetter));
@@ -49,6 +52,27 @@ public class NangmanPostBoxController {
         }catch (Exception e){
             //에러 발생 시 실패 응답 반환
             return ApiResponse.onFailure(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage(), null);
+        }
+    }
+
+    @GetMapping("/letter-list")
+    @ApiOperation(value = "낭만우편함 답장하기 - 편지 목록")
+    public ApiResponse<List<NangmanPostBoxResponseDTO.LetterSummaryResultDTO>> getLetterList(){
+        try{
+            //편지 목록 조회
+            List<NangmanLetter> letterList = nangmanPostBoxService.getLetterList();
+
+            //편지 내용의 두 줄만 포함하도록 변환
+            List<NangmanPostBoxResponseDTO.LetterSummaryResultDTO> letterSummaryDTOList = letterList.stream()
+                    .map(NangmanPostBoxConverter::toLetterSummaryResultDTO)
+                    .collect(Collectors.toList());
+
+            //성공 응답 생성
+            return ApiResponse.onSuccess(letterSummaryDTOList);
+        }catch (Exception e){
+            //에러 발생 시 실패 응답 반환
+            return ApiResponse.onFailure(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage(), null);
+
         }
     }
 }

--- a/src/main/java/aromanticcat/umcproject/web/dto/NangmanPostBoxResponseDTO.java
+++ b/src/main/java/aromanticcat/umcproject/web/dto/NangmanPostBoxResponseDTO.java
@@ -21,4 +21,16 @@ public class NangmanPostBoxResponseDTO {
 
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LetterSummaryResultDTO{
+        private Long nangmanLetterId;
+
+        private String preview;
+
+        private LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
feat/24 -> dev

### 💻 변경 사항
낭만우편함 고민 편지 목록 조회 API 구현 완료
편지 목록에서 각 편지 내용의 40자까지만 보일 수 있도록 DTO변환

### 🙏 테스트 결과
성공

