### PR TITLE
:sparkles: 내가 쓴 답장(+연결된 원본 편지) 목록 조회 API 구현

### DIFF
--- a/src/main/java/aromanticcat/umcproject/converter/NangmanLetterBoxConverter.java
+++ b/src/main/java/aromanticcat/umcproject/converter/NangmanLetterBoxConverter.java
@@ -66,13 +66,13 @@ public class NangmanLetterBoxConverter {
     public static NangmanLetterBoxResponseDTO.PreviewReplyResultDTO toPreviewReplyResultDTO(NangmanReply nangmanReply) {
 
         return NangmanLetterBoxResponseDTO.PreviewReplyResultDTO.builder()
-                .noReply(false)
                 .nangmanReplyId(nangmanReply.getId())
                 .nangmanLetterId(nangmanReply.getNangmanLetter().getId())
                 .preview(getPreviewText(nangmanReply.getContent()))
                 .build();
 
     }
+
 
     private static String getPreviewText(String content){
         // 답장 내용을 40자로 제한
@@ -81,5 +81,32 @@ public class NangmanLetterBoxConverter {
     }
 
 
+    public static NangmanLetterBoxResponseDTO.PreviewBothResultDTO toPreviewBothResultDTO(NangmanLetter nangmanLetter, NangmanReply nangmanReply){
+        return NangmanLetterBoxResponseDTO.PreviewBothResultDTO.builder()
+                .nangmanLetterId(nangmanLetter.getId())
+                .nangmanReplyId(nangmanReply.getId())
+                .previewLetter(getPreviewText(nangmanLetter.getContent()))
+                .previewReply(getPreviewText(nangmanReply.getContent()))
+                .totalEmojiCount(calculateTotalEmojiCount(nangmanLetter))
+                .createAt(nangmanReply.getCreatedAt())
+                .build();
+    }
 
+    private static Integer calculateTotalEmojiCount(NangmanLetter nangmanLetter){
+        // isPublic이 false이거나 hasResponse가 false이면 이모지 수를 계산하지 않음
+        if(!nangmanLetter.getIsPublic() || !nangmanLetter.getHasResponse()) {
+            return null;
+        }
+
+        // 각 이모지 수를 합산하여 반환
+        int thumbsUpCnt = nangmanLetter.getThumbsUpCnt();
+        int heartCnt = nangmanLetter.getHeartCnt();
+        int cryingCnt = nangmanLetter.getCryingCnt();
+        int cloverCnt = nangmanLetter.getCloverCnt();
+        int clapCnt = nangmanLetter.getClapCnt();
+        int starCnt = nangmanLetter.getStarCnt();
+
+        return thumbsUpCnt + heartCnt + cryingCnt + cloverCnt + clapCnt + starCnt;
+
+    }
 }

--- a/src/main/java/aromanticcat/umcproject/repository/NangmanReplyRepository.java
+++ b/src/main/java/aromanticcat/umcproject/repository/NangmanReplyRepository.java
@@ -4,6 +4,7 @@ import aromanticcat.umcproject.entity.NangmanReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface NangmanReplyRepository extends JpaRepository<NangmanReply, Long> {
@@ -11,4 +12,6 @@ public interface NangmanReplyRepository extends JpaRepository<NangmanReply, Long
     boolean existsByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
     Optional<NangmanReply> findByMemberIdAndNangmanLetterId(Long memberId, Long nangmanLetterId);
+
+    List<NangmanReply> findByMemberId(Long memberId);
 }

--- a/src/main/java/aromanticcat/umcproject/service/NangmanLetterBoxService.java
+++ b/src/main/java/aromanticcat/umcproject/service/NangmanLetterBoxService.java
@@ -20,11 +20,7 @@ public interface NangmanLetterBoxService {
 
     List<NangmanLetter> getNangmanLettersByUserId(Long userId);
 
-    NangmanLetterBoxResponseDTO.PreviewReplyResultDTO getPreviewReplyForLetter(Long userId, Long nangmanLetterId);
     Optional<NangmanReply> getReplyForLetter(Long userId, Long nangmanLetterId);
 
-
-//    NangmanLetterDTO readOne(Long id);
-//
-//    void receivedReply(NangmanLetterDTO nangmanLetterDTO);
+    List<NangmanLetterBoxResponseDTO.PreviewBothResultDTO> getReplyListByUserId(Long userId);
 }

--- a/src/main/java/aromanticcat/umcproject/web/controller/NangmanLetterBoxController.java
+++ b/src/main/java/aromanticcat/umcproject/web/controller/NangmanLetterBoxController.java
@@ -27,7 +27,7 @@ public class NangmanLetterBoxController {
     private final RandomNicknameService randomNicknameService;
 
     @GetMapping("/send/random-nickname")
-    @Operation(summary = "낭만우편함 편지 작성 -> 랜덤 닉네임 생성 API", description = "랜덤 생성된 닉네임을 조회(편지 작성하기 화면)하는 API입니다.")
+    @Operation(summary = "낭만우편함 편지 작성 - 랜덤 닉네임 생성 API", description = "랜덤 생성된 닉네임을 조회(편지 작성하기 화면)하는 API입니다.")
     public ApiResponse<String> getRandomNickname(){
         try {
             //랜덤 닉네임 생성
@@ -42,7 +42,7 @@ public class NangmanLetterBoxController {
 
 
     @PostMapping("/send")
-    @Operation(summary = "낭만우편함 편지 작성 -> 고민 편지 발송 API", description = "편지의 내용과 공개 여부 데이터를 넘기는 API 입니다. " )
+    @Operation(summary = "낭만우편함 편지 작성 - 편지 발송 API", description = "편지의 내용과 공개 여부 데이터를 넘기는 API 입니다. " )
     public ApiResponse<NangmanLetterBoxResponseDTO.WriteLetterResultDTO> sendLetter(@RequestBody NangmanLetterBoxRequestDTO.WriteLetterDTO request){
         try{
             //편지 작성 및 발송
@@ -61,7 +61,7 @@ public class NangmanLetterBoxController {
     }
 
     @GetMapping("/letter-list")
-    @Operation(summary = "낭만우편함 답장하기 -> 편지 목록 조회 API", description = "고민 편지 목록을 조회하는 API입니다. 각 편지는 40자까지 미리보기가 가능합니다.")
+    @Operation(summary = "낭만우편함 답장하기 - 편지 목록 조회 API", description = "고민 편지 목록을 조회하는 API입니다. 각 편지는 40자까지 미리보기가 가능합니다.")
     public ApiResponse<List<NangmanLetterBoxResponseDTO.PreviewLetterResultDTO>> getLetterList(){
         try{
             //편지 목록 조회
@@ -82,7 +82,7 @@ public class NangmanLetterBoxController {
     }
 
     @GetMapping("/letter-list/{nangmanLetterId}")
-    @Operation(summary  = "낭만우편함 답장하기 -> 답장할 편지 선택+조회 API", description = "선택된 편지의 상세 내용과 작성자의 랜덤 닉네임을 보여주고, 답장하는 사용자의 랜덤 닉네임을 생성해서 보여주는 API입니다. ")
+    @Operation(summary  = "낭만우편함 답장하기 -> 답장할 특정 편지 선택(상세조회), 랜덤 닉네임 얻기 API", description = "선택된 편지의 상세 내용과 작성자의 랜덤 닉네임을 보여주고, 답장하는 사용자의 랜덤 닉네임을 생성해서 보여주는 API입니다. ")
     public ApiResponse<NangmanLetterBoxResponseDTO.SelectedLetterResultDTO> getNangmanLetterInfo(@PathVariable Long nangmanLetterId){
        try{
            // 특정 편지에 대한 정보 조회
@@ -103,7 +103,7 @@ public class NangmanLetterBoxController {
     }
 
     @PostMapping("/letter-list/{nangmanLetterId}")
-    @Operation(summary  = "낭만우편함 답장하기 -> 답장 발송 API")
+    @Operation(summary  = "낭만우편함 답장하기 - 답장 발송 API")
     public ApiResponse<NangmanLetterBoxResponseDTO.WriteReplyResultDTO> sendReply(@PathVariable Long nangmanLetterId, @RequestBody NangmanLetterBoxRequestDTO.WriteReplyDTO request){
         try{
             //답장 작성 및 발송
@@ -121,7 +121,7 @@ public class NangmanLetterBoxController {
     }
 
     @GetMapping("/my/nangman-letters")
-    @Operation(summary = "낭만우편함 나의 편지 목록 조회 API", description = "사용자가 작성한 낭만 편지 목록을 조회하는 API입니다.")
+    @Operation(summary = "낭만우편함 나의 편지 (미리보기) 목록 조회 API", description = "사용자가 작성한 낭만 편지 목록을 조회하는 API입니다.")
     public ApiResponse<List<NangmanLetterBoxResponseDTO.PreviewLetterResultDTO>> getMyNangmanLetters() {
         try {
             // 현재 로그인된 사용자의 ID 또는 정보를 얻어온다고 가정
@@ -145,7 +145,7 @@ public class NangmanLetterBoxController {
     }
 
     @GetMapping("/my/nangman-letters/{nangmanLetterId}/preview-replies")
-    @Operation(summary = "낭만우편함 내가 쓴 편지에 대한 답장 프리뷰 조회 API", description = "특정 편지에 대한 답장 프리뷰(40자)를 조회하는 API입니다.")
+    @Operation(summary = "낭만우편함 내가 쓴 편지에 대한 답장 (미리보기) 조회 API", description = "특정 편지에 대한 답장 프리뷰(40자)를 조회하는 API입니다.")
     public ApiResponse<NangmanLetterBoxResponseDTO.PreviewReplyResultDTO> getPreviewReplyForLetter(@PathVariable Long nangmanLetterId) {
         try {
             // 현재 로그인된 사용자의 ID 또는 정보를 얻어온다고 가정
@@ -166,6 +166,20 @@ public class NangmanLetterBoxController {
             // 에러 발생 시 실패 응답 반환
             return ApiResponse.onFailure(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage(), null);
         }
+    }
+
+    @GetMapping("/my/nangman-replies")
+    @Operation(summary = "낭만우편함 내가 답장한 편지 (미리보기) 목록 조회 API", description = "사용자가 답장한 낭만 편지 목록을 조회하는 API입니다.")
+    public ApiResponse<List<NangmanLetterBoxResponseDTO.PreviewBothResultDTO>> getMyNangmanReplies() {
+        // 현재 로그인된 사용자의 ID 또는 정보를 얻어온다고 가정
+        // SecurityContextHolder에서 현재 사용자의 정보를 가져오는 방법
+        Long userId = getCurrentUserId(); // 로그인한 사용자의 아이디를 가져오는 메서드
+
+        // 사용자가 답장한 목록 조회
+        List<NangmanLetterBoxResponseDTO.PreviewBothResultDTO> userReplyList = nangmanLetterBoxService.getReplyListByUserId(userId);
+
+        // 성공 응답 생성
+        return ApiResponse.onSuccess(userReplyList);
     }
 
     //스프링 시큐리티 구현되기 전이라 임시 메서드입니다.

--- a/src/main/java/aromanticcat/umcproject/web/dto/nangmanLetterBox/NangmanLetterBoxResponseDTO.java
+++ b/src/main/java/aromanticcat/umcproject/web/dto/nangmanLetterBox/NangmanLetterBoxResponseDTO.java
@@ -13,20 +13,20 @@ public class NangmanLetterBoxResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class WriteLetterResultDTO {
+    public static class WriteLetterResultDTO { // 편지 발송 후 응답
 
         private Long nangmanLetterId;
 
         private String senderNickname;
 
-        LocalDateTime createdAt;
+        private LocalDateTime createdAt;
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PreviewLetterResultDTO {
+    public static class PreviewLetterResultDTO { // 편지 미리보기
         private Long nangmanLetterId;
 
         private String preview;
@@ -38,10 +38,8 @@ public class NangmanLetterBoxResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PreviewReplyResultDTO {
+    public static class PreviewReplyResultDTO { // 답장 미리보기
         private Long nangmanLetterId;
-
-        private Boolean noReply;
 
         private Long nangmanReplyId;
 
@@ -52,25 +50,40 @@ public class NangmanLetterBoxResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class SelectedLetterResultDTO {
+    public static class PreviewBothResultDTO{ // 편지 미리보기 + 답장 미리보기 + (공감 수)
         private Long nangmanLetterId;
-        private String senderNickname;
-        private String replySenderNickname;
-        private String nangmanLetterContent;
+
+        private Long nangmanReplyId;
+
+        private String previewLetter;
+
+        private String previewReply;
+
+        private Integer totalEmojiCount;
+
+        private LocalDateTime createAt;
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class WriteReplyResultDTO {
+    public static class SelectedLetterResultDTO { // 편지 선택 후 응답
+        private Long nangmanLetterId;
+        private String senderNickname;
+        private String nangmanLetterContent;
+        private String replySenderNickname;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WriteReplyResultDTO { // 답장 발송 완료 응답
 
         private Long nangmanLetterId;
-
         private Long nangmanReplyId;
-
         private String replySenderNickname;
-
         LocalDateTime createdAt;
     }
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
feat/51-> dev

### 💻 변경 사항
낭만우편함 - 내가 답장한 편지 조회 기능 구현

현재 로그인한 유저가 쓴 답장과, 답장에 연결된 원본 편지의 내용을 각각 40자까지 제공


### 🙏 테스트 결과
성공

close #51 